### PR TITLE
chore: upgrade GitHub Actions to use checkout v5 and Go v6

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,13 +20,13 @@ jobs:
 
     timeout-minutes: 2
     steps:
-      - name: Checkout v4
-        uses: actions/checkout@v4
+      - name: Checkout v5
+        uses: actions/checkout@v5
 
-      - name: Go setup v5
-        uses: actions/setup-go@v5
+      - name: Go setup v6
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.23
+          go-version: 1.25
           check-latest: true
 
       - name: Verify dependencies
@@ -59,14 +59,14 @@ jobs:
     
     strategy:
       matrix:
-        go-version: ["1.22","1.23"]
+        go-version: ["1.23","1.24","1.25"]
     
     steps:
-      - name: Checkout v4
-        uses: actions/checkout@v4
+      - name: Checkout v5
+        uses: actions/checkout@v5
 
-      - name: Go setup v5
-        uses: actions/setup-go@v5
+      - name: Go setup v6
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true


### PR DESCRIPTION
# Description


## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## [optional] What gif best describes this PR or how it makes you feel?
